### PR TITLE
Bump s3-deploy and small build.boot fix

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -8,7 +8,11 @@
 (def +version+ "0.1.2-SNAPSHOT")
 (bootlaces! +version+)
 
-(def creds (read-string (slurp "aws-cred.edn")))
+(def creds (try
+             (read-string (slurp "aws-cred.edn"))
+             (catch java.io.FileNotFoundException e
+               (boot.util/warn "aws-cred.edn not found, no authentication will be performed\n")
+               "nil")))
 
 (task-options!
  sync-bucket {:secret-key (:secret-key creds)

--- a/src/confetti/boot_confetti.clj
+++ b/src/confetti/boot_confetti.clj
@@ -10,7 +10,7 @@
 
 (def deps '[[camel-snake-kebab "0.3.2"]
             [confetti/cloudformation "0.1.0-SNAPSHOT"]
-            [confetti/s3-deploy "0.1.0-SNAPSHOT"]
+            [confetti/s3-deploy "0.1.1"]
             [com.google.guava/guava "18.0"]])
 
 (defn confetti-pod []


### PR DESCRIPTION
Simple bump so match the bug fix.

I was thinking that it would probably makes sense to merge the three libraries as it is not very convenient (at least it would not be if I were the maintainer) to update `confetti` everytime you update either `s3-deploy` or `cloudformation`.